### PR TITLE
Shuffle earlier when shoe is half

### DIFF
--- a/js/game.js
+++ b/js/game.js
@@ -48,7 +48,8 @@ class Game {
      */
     initGame(bet) {
         this.bet = bet;
-        if (this.deck.getRemainingCards() < 50) {
+        // 残りデッキ数が3未満になったらシャッフル
+        if (this.deck.getRemainingCards() < 52 * 3) {
             this.deck.reset();
         }
         this.playerHands = [new Hand(bet, false)];

--- a/js/ui.js
+++ b/js/ui.js
@@ -402,7 +402,8 @@ class GameUI {
         
         // カードカウンティングの処理
         // シャッフル時はカウンティングをリセット
-        if (this.game.deck.getRemainingCards() < 50) {
+        // 残りデッキ数が3未満になったらカウンティングをリセット
+        if (this.game.deck.getRemainingCards() < 52 * 3) {
             this.cardCounting.reset();
             // カウンティング表示もリセット
             this.runningCountElement.textContent = 0;


### PR DESCRIPTION
## Summary
- reshuffle the deck when fewer than three decks remain
- reset counting display in UI after shuffle

## Testing
- `npm test` *(fails: could not read `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_684fb1fdacec832ca09cf4adb0100217